### PR TITLE
Check if grad is none instead

### DIFF
--- a/recipes/create_trainer.py
+++ b/recipes/create_trainer.py
@@ -1,7 +1,7 @@
 from workflow.ignite.decorators import train
 
 
-@train(model, optimizer, n_n_batches_per_step=2)
+@train(model, optimizer, n_batches_per_step=2)
 def train_batch(engine, batch):
     batch['predictions'] = model(batch['features'])
     loss_ = loss(batch)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='ml-workflow',
-    version='0.2.1',
+    version='0.2.2',
     description='Workflow tools for pytorch and ignite',
     author='Felix Abrahamsson, Richard Löwenström, Jim Holmström',
     author_email='richard@aiwizo.com',

--- a/workflow/ignite/decorators/step.py
+++ b/workflow/ignite/decorators/step.py
@@ -11,7 +11,7 @@ def step(optimizer, n_batches_per_step=1):
             if engine.state.iteration % n_batches_per_step == 0:
                 for param_group in optimizer.param_groups:
                     for parameters in param_group['params']:
-                        if parameters.requires_grad:
+                        if parameters.grad is not None:
                             parameters.grad.div_(n_batches_per_step)
 
                 optimizer.step()


### PR DESCRIPTION
Continues from PR #27. Ignore "Fix create trainer recipe".

They also check if grad is none in the pytorch optimizer implementation.

Bugfix, also bumping version.