### PR TITLE
feature: Add commitizen configuration

### DIFF
--- a/template/cookiecutter.json
+++ b/template/cookiecutter.json
@@ -2,5 +2,6 @@
     "repository_name": "my-repo-name",
     "package_name": "{{ cookiecutter.repository_name.lower().replace(' ', '_').replace('-', '_') }}",
     "package_version": "0.0.1",
-    "package_description": "Short description"
+    "package_description": "Short description",
+    "_copy_without_render": [".cz.toml"]
 }

--- a/template/{{cookiecutter.repository_name}}/.cz.toml
+++ b/template/{{cookiecutter.repository_name}}/.cz.toml
@@ -1,0 +1,33 @@
+[tool.commitizen]
+name = "cz_customize"
+
+[tool.commitizen.customize]
+message_template = "{{change_type}}:{% if show_message %} {{message}}{% endif %}"
+example = "feature: this feature enables customization through config file"
+schema = "<type>: <body>"
+bump_pattern = "^(break|new|fix|hotfix)"
+bump_map = {"break" = "MAJOR", "new" = "MINOR", "fix" = "PATCH", "hotfix" = "PATCH"}
+info_path = "cz_customize_info.txt"
+
+[[tool.commitizen.customize.questions]]
+type = "list"
+name = "change_type"
+choices = [
+    {value = "feature", name = "feature: Ads a new feature."},
+    {value = "fix", name = "fix: Corrects an error in an existing feature."},
+    {value = "tune", name = "tune: Tunes/improves an existing feature."},
+    {value = "refactor", name = "refactor: Refactors code."},
+    {value = "doc", name = "doc: Adds documentation."},
+    {value = "revert", name = "revert: A revert commit."},
+]
+message = "Select the type of change you are committing"
+
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "message"
+message = "Body:"
+
+[[tool.commitizen.customize.questions]]
+type = "confirm"
+name = "show_message"
+message = "Do you want to add body message in commit?"

--- a/template/{{cookiecutter.repository_name}}/requirements.txt
+++ b/template/{{cookiecutter.repository_name}}/requirements.txt
@@ -8,6 +8,7 @@ cachetools==4.1.0
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.2
+commitizen==2.1.0
 cookiecutter==1.7.2
 daemonize==2.5.0
 decorator==4.4.2


### PR DESCRIPTION
Adds commitizen to template. Right now only single-line commit messages are allowed, do we want this?